### PR TITLE
Add README and global insarchitect alias for Pixi installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ temp/
 SLC
 DEM
 
+asf*
+
+activate.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+
+# InSARchitect
+InSARChitect is an orchestrator that integrates ISCE2, MiaplPy, and MintPy within a cluster-based architecture to streamline and automate InSAR processing workflows.
+
+
+## Installation
+
+Run the following script:
+
+```bash
+bash scripts/install.sh
+```
+
+This will install `pixi`, download the required packages, and clone and install
+repositories such as `ISCE2`, `MintPy`, and `MiaplPy`.
+
+IMPORTANT: Be sure you have the correct access permissions for these private repositories.
+
+After the installation process, open a new bash session
+
+```bash
+bash
+```
+
+Then, activate the environment
+```bash
+insarchitect.load
+```
+
+Run the program
+
+```bash
+insarchitect <command> <template.toml>
+```
+
+Example
+
+```bash
+insarchitect download templates/galapagos.toml
+```

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TOOLS_DIR="${PROJECT_ROOT}/tools"
+
+export MINTPY_HOME="${TOOLS_DIR}/MintPy"
+export MIAPLPY_HOME="${TOOLS_DIR}/MiaplPy"
+export ISCE_HOME="${TOOLS_DIR}/isce2"
+export INSARMAPS_SCRIPTS_HOME="${TOOLS_DIR}/insarmaps-scripts"
+
+[ -d "${MINTPY_HOME}" ] && export PYTHONPATH="${MINTPY_HOME}:${PYTHONPATH}"
+[ -d "${MIAPLPY_HOME}" ] && export PYTHONPATH="${MIAPLPY_HOME}:${PYTHONPATH}"
+[ -d "${ISCE_HOME}" ] && export PYTHONPATH="${ISCE_HOME}:${PYTHONPATH}"
+
+[ -d "${MINTPY_HOME}/src/mintpy" ] && export PATH="${MINTPY_HOME}/src/mintpy:${PATH}"
+[ -d "${MIAPLPY_HOME}/src/miaplpy" ] && export PATH="${MIAPLPY_HOME}/src/miaplpy:${PATH}"
+
+export PATH="${INSARMAPS_SCRIPTS_HOME}:${PATH}"
+
+echo "InSARchitect environment variables set"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,11 +47,43 @@ pixi run install
 echo -e "${GREEN}Installing additional InSAR packages (ISCE2, MintPy, MiaplPy)...${NC}"
 pixi run install-extra
 
+echo -e "${GREEN}Generating pixi shell hook${NC}"
+
+pixi shell-hook > "${PROJECT_ROOT}/activate.sh"
+
+# add the original path 
+sed -i 's|^export PATH="|export PATH="$PATH:|' "${PROJECT_ROOT}/activate.sh"
+
+ALIAS_NAME="insarchitect.load"
+ALIAS_VALUE="source ${PROJECT_ROOT}/activate.sh"
+BASHRC="$HOME/.bashrc"
+
+if grep -qF "alias ${ALIAS_NAME}='${ALIAS_VALUE}'" "$BASHRC"; then
+    echo "The alias ${ALIAS_NAME} already exists and is correct"
+elif grep -qE "^alias[[:space:]]+${ALIAS_NAME}=" "$BASHRC"; then
+    echo "Alias ${ALIAS_NAME} exists but is different. Overwriting..."
+    sed -i.bak "s|^alias[[:space:]]\+${ALIAS_NAME}=.*|alias ${ALIAS_NAME}='${ALIAS_VALUE}'|" "$BASHRC"
+else
+    echo "Creating load alias..."
+    echo -e "\nalias ${ALIAS_NAME}='${ALIAS_VALUE}'" >> "$BASHRC"
+fi
+
+if grep -qE "^alias insarchitect=" ~/.bashrc; then
+    echo "The alias insarchitect already exists"
+else
+    echo "Creating insarchitect alias..."
+    echo -e "\nalias insarchitect='pixi run insarchitect'" >> ~/.bashrc
+fi
+
 echo -e "${GREEN}========================================${NC}"
 echo -e "${GREEN}Installation completed successfully!${NC}"
 echo -e "${GREEN}========================================${NC}"
+
+
+echo -e "\n  ${YELLOW}Close your current terminal and open a new bash session${NC}\n"
+
 echo "To activate the environment, run:"
-echo -e "  ${YELLOW}pixi shell${NC}"
-echo "Or run commands directly with:"
-echo -e "  ${YELLOW}pixi run insarchitect${NC}"
+echo -e "  ${YELLOW}insarchitect.load${NC}"
+echo "Run commands directly with:"
+echo -e "  ${YELLOW}insarchitect${NC}"
 


### PR DESCRIPTION
# Changelog
- [x] Added README documentation
- [x] Pixi installation now adds an `insarchitect` alias that can be run from any location on Linux
