### PR TITLE
Add support step selection and execution order in run command

### DIFF
--- a/src/insarchitect/cli.py
+++ b/src/insarchitect/cli.py
@@ -1,9 +1,10 @@
 import typer
-from .commands import download, jobfiles
+from .commands import download, jobfiles, dem
 
 app = typer.Typer()
 
 app.add_typer(download.app)
+app.add_typer(dem.app)
 app.add_typer(jobfiles.app)
 
 if __name__ == "__main__":

--- a/src/insarchitect/cli.py
+++ b/src/insarchitect/cli.py
@@ -1,11 +1,12 @@
 import typer
-from .commands import download, jobfiles, dem
+from .commands import download, jobfiles, dem, run
 
 app = typer.Typer()
 
 app.add_typer(download.app)
 app.add_typer(dem.app)
 app.add_typer(jobfiles.app)
+app.add_typer(run.app)
 
 if __name__ == "__main__":
     app()

--- a/src/insarchitect/commands/dem.py
+++ b/src/insarchitect/commands/dem.py
@@ -1,0 +1,25 @@
+import typer
+from pathlib import Path
+from typing_extensions import Annotated
+
+from ..config import load_config
+from ..core.dem.dem import dem_main
+
+app = typer.Typer(help="Creates a DEM based on ssara_*.kml file using COPERNICUS or NASA")
+
+ConfigFile = Annotated[Path, typer.Argument(help="Path to configuration TOML file")]
+
+@app.command()
+def dem(config_file: ConfigFile):
+    """
+    Download DEM based on template file and KML bounding box.
+    
+    Example:
+        pixi run insarchitect dem <template>
+    """
+
+    project_config = load_config(config_file)
+    dem_main(project_config)
+
+if __name__ == "__main__":
+    app()

--- a/src/insarchitect/commands/run.py
+++ b/src/insarchitect/commands/run.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import typer
+from typing_extensions import Annotated
+
+import insarchitect.cli.commands.download as download
+import insarchitect.cli.commands.download_dem as download_dem
+
+app = typer.Typer()
+
+ConfigFile = Annotated[Path, typer.Argument(help="Path to configuration TOML file")]
+
+app = typer.Typer()
+
+app.add_typer(download.app)
+app.add_typer(download_dem.app)
+
+@app.command()
+def run(
+    config_file: Annotated[Path, typer.Argument(help="Configuration file to process")]
+):
+    """
+    Run all processing steps with the given config file
+    """
+    typer.echo(f"Processing config file: {config_file}")
+    download.download(config_file)
+    download_dem.download_dem(config_file)
+
+if __name__ == "__main__":
+    app()
+

--- a/src/insarchitect/commands/run.py
+++ b/src/insarchitect/commands/run.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from insarchitect.models import ProjectConfig
 import typer
 from typing_extensions import Annotated
+from typing import Callable, Optional
 
 from ..config import load_config
 from ..core.download.download import download_main
@@ -12,20 +13,86 @@ app = typer.Typer()
 
 ConfigFile = Annotated[Path, typer.Argument(help="Path to configuration TOML file")]
 
+STEPS = {
+    "download": (download_main, "Download step"),
+    "dem": (dem_main, "DEM processing step"),
+    "jobfiles": (download_orbits, "Job files generation (orbits)"),
+    "isce": (None, "ISCE processing step (to be implemented)"),
+}
+
+# execution order
+STEP_ORDER = ["download", "dem", "jobfiles", "isce"]
+
+def _get_step_function(step_name: str) -> Optional[Callable]:
+    """Get the function for a step, handling not-yet-implemented steps"""
+    func, _ = STEPS[step_name]
+    if func is None:
+        typer.echo(f"Warning: {step_name} step is not yet implemented")
+        return None
+    return func
+
 @app.command()
 def run(
-    config_file: Annotated[Path, typer.Argument(help="Configuration file to process")]
+    config_file: Annotated[Path, typer.Argument(help="Configuration file to process")],
+    download: Annotated[bool, typer.Option("--download", help="Run download step")] = False,
+    dem: Annotated[bool, typer.Option("--dem", help="Run DEM processing step")] = False,
+    jobfiles: Annotated[bool, typer.Option("--jobfiles", help="Run job files generation step")] = False,
+    isce: Annotated[bool, typer.Option("--isce", help="Run ISCE processing step (to be implemented)")] = False,
+    start: Annotated[Optional[str], typer.Option("--start", help="Start from a specific step (e.g., --start jobfiles)")] = None,
 ):
     """
-    Run all processing steps with the given config file
+    Run processing steps with the given config file
+    
+    If no flags are specified, all steps will be executed.
+    Use flags to run only specific steps (e.g., --download --dem).
+    Use --start to run from a specific step onwards (e.g., --start jobfiles).
     """
     project_config = load_config(config_file)
-
     typer.echo(f"Processing config file: {config_file}")
 
-    download_main(project_config)
-    dem_main(project_config)
-    download_orbits(project_config)
+    if start is not None:
+        if start not in STEPS:
+            typer.echo(f"Error: Unknown step '{start}'. Available steps: {', '.join(STEPS.keys())}")
+            raise typer.Exit(1)
+        
+        # find the index of the start step
+        try:
+            start_index = STEP_ORDER.index(start)
+        except ValueError:
+            typer.echo(f"Error: Step '{start}' is not in the execution order.")
+            raise typer.Exit(1)
+        
+        # get all steps from start onwards
+        selected_steps = set(STEP_ORDER[start_index:])
+        typer.echo(f"Starting from step '{start}'...")
+    else:
+        # just add the flag parameter below if you add a new step
+        # add as string to find the step name in the STEP_ORDER list
+        flag_to_step = {
+            "download": download,
+            "dem": dem,
+            "jobfiles": jobfiles,
+            "isce": isce,
+        }
+        
+        # determine which steps to run
+        selected_steps = {step for step, flag in flag_to_step.items() if flag}
+        
+        # if no flags specified, run all available steps (e.g. insarchitect run <config_file>)
+        if not selected_steps:
+            selected_steps = set(STEPS.keys())
+            typer.echo("Running all processing steps...")
+        else:
+            typer.echo("Running selected processing steps...")
+    
+    # execute steps in defined order
+    for step_name in STEP_ORDER:
+        if step_name in selected_steps:
+            _, description = STEPS[step_name]
+            typer.echo(f"Running {description}...")
+            func = _get_step_function(step_name)
+            if func:
+                func(project_config)
 
 if __name__ == "__main__":
     app()

--- a/src/insarchitect/commands/run.py
+++ b/src/insarchitect/commands/run.py
@@ -1,19 +1,16 @@
 from pathlib import Path
-
+from insarchitect.models import ProjectConfig
 import typer
 from typing_extensions import Annotated
 
-import insarchitect.cli.commands.download as download
-import insarchitect.cli.commands.download_dem as download_dem
+from ..config import load_config
+from ..core.download.download import download_main
+from ..core.dem.dem import dem_main
+from ..core.jobfiles.download_orbits import download_orbits
 
 app = typer.Typer()
 
 ConfigFile = Annotated[Path, typer.Argument(help="Path to configuration TOML file")]
-
-app = typer.Typer()
-
-app.add_typer(download.app)
-app.add_typer(download_dem.app)
 
 @app.command()
 def run(
@@ -22,9 +19,13 @@ def run(
     """
     Run all processing steps with the given config file
     """
+    project_config = load_config(config_file)
+
     typer.echo(f"Processing config file: {config_file}")
-    download.download(config_file)
-    download_dem.download_dem(config_file)
+
+    download_main(project_config)
+    dem_main(project_config)
+    download_orbits(project_config)
 
 if __name__ == "__main__":
     app()

--- a/src/insarchitect/core/dem/dem.py
+++ b/src/insarchitect/core/dem/dem.py
@@ -1,0 +1,200 @@
+from pathlib import Path
+import os
+import sys
+
+import math
+import shutil
+from rich import print
+
+import sardem.dem
+from insarchitect.config import load_config
+import insarchitect.core.dem.get_boundingbox_from_kml as boundingbox_from_kml 
+
+from ...models import ProjectConfig
+
+
+def format_bbox(bbox: tuple) -> str:
+    """
+    Format bounding box to readable string format.
+    
+    Args:
+        bbox: List or tuple of [west, south, east, north]
+    
+    Returns:
+        Formatted string like "S00_N01_W078_W076"
+    """
+    west, south, east, north = bbox
+
+    # Determine hemisphere for each coordinate
+    south_str = f"S{abs(south):02d}" if south < 0 else f"N{abs(south):02d}"
+    north_str = f"S{abs(north):02d}" if north < 0 else f"N{abs(north):02d}"
+    west_str = f"W{abs(west):03d}" if west < 0 else f"E{abs(west):03d}"
+    east_str = f"W{abs(east):03d}" if east < 0 else f"E{abs(east):03d}"
+
+    # Format the output string
+    name = f"{south_str}_{north_str}_{west_str}_{east_str}"
+    return name
+
+
+def exist_valid_dem_dir(dem_dir: Path) -> bool:
+    """
+    Check if a valid DEM directory exists.
+    
+    Args:
+        dem_dir: Path to DEM directory
+    
+    Returns:
+        True if valid DEM exists, False otherwise
+        
+    Note:
+        If directory exists but doesn't contain valid products, it will be removed.
+    """
+    if dem_dir.is_dir():
+        products = list(dem_dir.glob('*dem.wgs84*'))
+        if len(products) >= 3:
+            print('[bold yellow]\nDEM products already exist. If not satisfying, remove the folder and run again[/bold yellow]')
+            return True
+        else:
+            print('[bold yellow]\nIncomplete DEM directory found. Removing and recreating...[/bold yellow]')
+            shutil.rmtree(dem_dir)
+            return False
+    else:
+        return False
+
+
+def dem_main(config: ProjectConfig):
+    """
+    Download DEM based on template file and KML bounding box.
+    
+    This function:
+    1. Reads the configuration from the template file
+    2. Locates the SSARA KML file with bounding box information
+    3. Extracts the bounding box coordinates
+    4. Downloads the DEM using sardem from Copernicus or NASA DEM
+    5. Creates ISCE-compatible XML files
+    """
+    
+    # Get config
+    download_asf_config = config.download
+    if download_asf_config is None:
+        print(f"[bold red]No valid configuration given for download command[/bold red]")
+        sys.exit(1)
+    
+    download_dem_config = config.dem   
+    if download_dem_config is None:
+        print(f"[bold red]No valid configuration given for dem command[/bold red]")
+        sys.exit(1)
+    
+    # Set directories
+    work_dir = config.system.work_dir / config.project_name
+    data_source = download_dem_config.data_source.value
+    dem_dir = work_dir / download_dem_config.dem_dir
+    slc_dir = work_dir / download_asf_config.slc_dir
+    
+    print(f"[bold green]{'='*60}[/bold green]")
+    print("[bold green]DEM DOWNLOAD[/bold green]")
+    print(f"[bold green]{'='*60}[/bold green]")
+    print(f"[bold]Working directory[/bold]: {work_dir}")
+    print(f"[bold]DEM directory[/bold]:  {dem_dir}")
+    
+    # Check for existing valid DEM
+    if exist_valid_dem_dir(dem_dir):
+        print("\n[bold cyan]Valid DEM already exists. Exiting.[/bold cyan]")
+        sys.exit(1)
+    
+    # Create DEM directory
+    dem_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Adjust SLC directory based on platform
+    """ values = [str(v).upper() for v in dem_download_config.__dict__.values()]
+    if any("COSMO-SKYMED" in value for value in values):
+        slc_dir = Path(str(slc_dir).replace('SLC', 'RAW_data'))
+        print(f"[bold]Platform detected: COSMO-SKYMED, using RAW_data directory[/bold]")
+    if any("TSX" in value for value in values):
+        slc_dir = Path(str(slc_dir).replace('SLC', 'SLC_ORIG'))
+        print(f"[bold]Platform detected: TerraSAR-X, using SLC_ORIG directory[/bold]") """
+    
+    # Find KML file
+    print('[bold magenta]\nSearching for KML file...\n[/bold magenta]')
+    try:
+        kml_files = sorted(slc_dir.glob('ssara_*.kml'))
+        if not kml_files:
+            raise FileNotFoundError(
+                f'[bold red]No ssara_*.kml found in {slc_dir}\n'
+                'Please run the download command first to generate the KML file.[/bold red]'
+            )
+        ssara_kml_file = kml_files[-1]
+    except Exception as e:
+        print(f'[bold red]Error finding KML file: {e}[/bold red]')
+        sys.exit(1)
+    
+    print(f'[bold]Using KML file[/bold]: {ssara_kml_file.name}')
+    
+    # Get bounding box from KML
+    print('[bold magenta]\nExtracting bounding box from KML...\n[/bold magenta]')
+    try:
+        bbox = boundingbox_from_kml.main( [str(ssara_kml_file), '--delta_lon', '0'] )    
+    except Exception as e:
+        print(f'[bold red]Problem with KML file: {e}[/bold red]')
+        sys.exit(1)
+    
+    # Parse bbox string
+    bbox = bbox.split('SNWE:')[1]
+    bbox = [val for val in bbox.split()]
+
+    south = bbox[0]
+    north = bbox[1]
+    west = bbox[2]
+    east = bbox[3].split('\'')[0]
+
+    # Expand bbox with buffer
+    south = math.floor(float(south))
+    north = math.ceil(float(north))
+    west = math.floor(float(west))
+    east = math.ceil(float(east))
+    
+    # Format bbox for sardem (Left, Bottom, Right, Top)
+    bbox_LeftBottomRightTop = [int(west), int(south), int(east), int(north)]
+    print(f"[bold]Bounding box[/bold]: {bbox_LeftBottomRightTop}")
+
+    output_name = f"elevation_{format_bbox(bbox_LeftBottomRightTop)}.dem"
+    data_source_str = "NASA DEM" if data_source == "NASA" else "Copernicus DEM"
+    print('[bold magenta]\nDownloading DEM...\n[/bold magenta]')
+    print(f"[bold]Output file[/bold]: {output_name}")
+    print(f"[bold]Data source[/bold]: {data_source_str}")
+    
+    command = (
+        f"sardem --bbox {int(west)} {int(south)} {int(east)} {int(north)} "
+        f"--data {data_source} --make-isce-xml --output {output_name}"
+    )
+    print(f"[bold magenta]\nSARDEM execution...\n[/bold magenta]")
+    print(f'[bold]Command[/bold]: {command}')
+    # Change to DEM directory
+    original_dir = Path.cwd()
+    os.chdir(dem_dir)
+    
+    try:
+        sardem.dem.main(
+            bbox=bbox_LeftBottomRightTop,
+            data_source=data_source,
+            make_isce_xml=True,
+            output_name=output_name
+        )
+        # Verify output files
+        dem_files = list(Path('.').glob(f'{output_name}*'))
+        if dem_files:
+            print("[bold]\nCreated files[/bold]:")
+            for f in sorted(dem_files):
+                print(f"  - [bold cyan]{f.name}[/bold cyan]")
+        print(f"[bold green]{'='*60}[/bold green]")
+        print('[bold green]DEM DOWNLOAD COMPLETED SUCESSFULLY[/bold green]')
+        print(f"[bold green]{'='*60}[/bold green]")
+        
+    except KeyboardInterrupt:
+        print("[bold red]\nDownload interrupted by user[/bold red]")
+        sys.exit(1)
+    except Exception as e:
+        print(f"[bold red]\nERROR during DEM download: {e}[/bold red]")
+        sys.exit(1)
+    finally:
+        os.chdir(original_dir)

--- a/src/insarchitect/core/dem/get_boundingbox_from_kml.py
+++ b/src/insarchitect/core/dem/get_boundingbox_from_kml.py
@@ -1,0 +1,98 @@
+###############################################
+# Program is used for preparing DEM data      #
+# Author: Lv Xiaoran                          #
+# Created: October 2021                       #
+###############################################
+
+import argparse
+import numpy as np
+import xml.etree.ElementTree as ET
+
+EXAMPLE = """Example:
+   get_boundingbox_from_kml.py *_20211019042049.kml —-delta_lat 0.5 —-delta_lon 1.2
+"""
+
+def create_parser():
+    parser = argparse.ArgumentParser(description='Get bounding box coordinates from kml file',
+                                     formatter_class=argparse.RawTextHelpFormatter,
+                                     epilog=EXAMPLE)
+
+    parser.add_argument('file', nargs=1, type=str, help='kml file\n')
+    parser.add_argument('--delta_lat', type=float, nargs=1, help='Delta latitude to subtract/add from minimum/maximimum latitude', default=[0.0])
+    parser.add_argument('--delta_lon', nargs=1, type=float, help='Delta longitude to subtract/add from minimum/maximimum longitude', default=[0.0])
+
+    return parser
+
+def cmd_line_parse(iargs=None):
+    parser = create_parser()
+    inps = parser.parse_args(args=iargs)
+    return inps
+
+def process_kml(kml_file, delta_lat, delta_lon):
+    """
+    Main code to extract bounding box from KML file.
+    
+    Args:
+        kml_file: Path to KML file (str or Path)
+        delta_lat: Delta latitude to subtract/add from min/max latitude
+        delta_lon: Delta longitude to subtract/add from min/max longitude
+    
+    Returns:
+        Tuple of (lat_min, lat_max, lon_min, lon_max)
+    """
+    tree = ET.parse(kml_file)
+    #root = tree.getroot()
+
+    # read lon/lat coordinate into latlon_store matrix
+    lineStrings = tree.findall('.//{http://earth.google.com/kml/2.1}LineString')
+    if not lineStrings:
+        lineStrings = tree.findall('.//{http://www.opengis.net/kml/2.2}LinearRing')
+        latlon_store = np.empty(shape=[0,2], dtype=float)
+        for attributes in lineStrings:
+            for sub in attributes:
+                if sub.tag == '{http://www.opengis.net/kml/2.2}coordinates':
+                    corners = sub.text.split()
+                    for corner in corners[0:-1]:
+                        lon, lat, _ = corner.split(',')
+                        latlon_store = np.append(latlon_store,np.array([[float(lon), float(lat)]]),axis=0)
+    else:
+        latlon_store = np.empty(shape=[0,2],dtype=float)
+        for attributes in lineStrings:
+            for subAttribute in attributes:
+                if subAttribute.tag == '{http://earth.google.com/kml/2.1}coordinates':
+                    corners = subAttribute.text.split(' ')
+                    for corner in corners[0:-1]:
+                        lon, lat, _ = corner.split(',')
+                        latlon_store = np.append(latlon_store,np.array([[float(lon), float(lat)]]),axis=0)
+    # select the max/min lat and lon
+    lat_max = np.max(latlon_store[:,1])
+    lat_min = np.min(latlon_store[:,1])
+
+    lon_max = np.max(latlon_store[:,0])
+    lon_min = np.min(latlon_store[:,0])
+
+    # add the delta_lat/delta_lon
+    lat_max2 = np.around((lat_max + delta_lat), 1)
+    lat_min2 = np.around((lat_min - delta_lat), 1)
+
+    lon_max2 = np.around((lon_max + delta_lon), 1)
+    lon_min2 = np.around((lon_min - delta_lon), 1)
+
+    return lat_min2, lat_max2, lon_min2, lon_max2
+
+def main(iargs=None):
+    inps = cmd_line_parse(iargs)
+
+    kml_file = inps.file[0]
+
+    delta_lat = inps.delta_lat[0]
+    delta_lon = inps.delta_lon[0]
+
+    lat_min2, lat_max2, lon_min2, lon_max2 = process_kml(kml_file=kml_file, delta_lat=delta_lat, delta_lon=delta_lon)
+
+    lat_lon_str = f'SNWE: {lat_min2} {lat_max2} {lon_min2} {lon_max2}'
+    
+    return lat_lon_str
+
+if __name__ == '__main__':
+    main()

--- a/src/insarchitect/models.py
+++ b/src/insarchitect/models.py
@@ -33,7 +33,7 @@ class DataSource(str, Enum):
     NASA = "NASA"
 
 class DemConfig(BaseModel):
-    data_source: DataSource = Field(DataSource.COP, description="Which data_source to download Dem from [COP, NASA]")
+    data_source: DataSource = Field(DataSource.COP, description="Which DEM provider to use [COP, NASA]")
     dem_dir: Path = Field(Path("./DEM"), description="Directory to save downloaded DEM")
 
 # ========= Jobfiles ========= #

--- a/templates/galapagos.toml
+++ b/templates/galapagos.toml
@@ -11,7 +11,7 @@ slc_dir                 = "./SLC"
 
 [dem]
 work_dir                = "."
-data_source             = "COP"
+data_source             = "NASA"
 
 [jobfiles]
 jobfiles_dir            = "./run_files"


### PR DESCRIPTION
Add the following flags:

- [x] `--start <start_step>`: allows running the pipeline starting from a specific step, e.g. `insarchitect run <template.toml> --start dem`
- [x] `--<selected_step>`: allows running one or more specific steps (multiple steps supported), e.g. `insarchitect run <template.toml> --dem --download`
The order of the flags does not matter, step execution order is handled automatically via the `STEP_ORDER` variable
- [x] Add an ISCE flag as an example for future implementations.